### PR TITLE
Update Gradle for kotlin development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,23 @@
 buildscript {
     ext {
         springBootVersion = '2.1.0.RELEASE'
+        ext.kotlin_version = '1.1.4-3'
     }
     repositories {
         mavenCentral()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-noarg:$kotlin_version"
     }
 }
 
+
+
 apply plugin: 'java'
+apply plugin:'kotlin'
+apply plugin: "kotlin-jpa"
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
@@ -25,18 +32,21 @@ repositories {
 
 
 dependencies {
-    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
-    implementation('org.springframework.boot:spring-boot-starter-web')
-    runtimeOnly('com.h2database:h2')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    // https://mvnrepository.com/artifact/com.github.javafaker/javafaker
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly('com.h2database:h2')
+    
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.16'
     
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.0.1'
     compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test')
-    // https://mvnrepository.com/artifact/org.jmockit/jmockit
-    testCompile group: 'org.jmockit', name: 'jmockit', version: '1.8'
+    testImplementation group: 'org.jmockit', name: 'jmockit', version: '1.8'
 
+    testImplementation  'junit:junit:4.11'
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }


### PR DESCRIPTION
Add kotlin gradle plugin to the build.gradle scripts. Add the kotlin
runtime library and the kotlin reflection library.

After this commit, the application should be able to freely mix kotlin
and java projgraming. The project should work to migrating to kotlin.